### PR TITLE
Potential fix for code scanning alert no. 9: Use of insecure SSL/TLS version

### DIFF
--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -341,6 +341,7 @@ class Test(BaseTest):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.verify_mode = ssl.CERT_REQUIRED
         context.load_verify_locations(CACERT)
         context.load_cert_chain(certfile=CLIENT2, keyfile=CLIENTKEY2)


### PR DESCRIPTION
Potential fix for [https://github.com/securityuniverse/beats/security/code-scanning/9](https://github.com/securityuniverse/beats/security/code-scanning/9)

To fix the problem, we need to ensure that the SSL/TLS context created by `ssl.create_default_context` only allows secure protocol versions (TLS 1.2 and above). This can be achieved by setting the `minimum_version` attribute of the context to `ssl.TLSVersion.TLSv1_2`. This change ensures that the context will not use any insecure versions of SSL/TLS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
